### PR TITLE
Add rate limining for acccess

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,4 +279,17 @@ Remember that you must send in the body the params
 ```
 
 
-RATE LIMITING!!!!
+### How we handle the number of requests?
+Depending on the role in the system, the allowed requests are calculated
+
+## Anonymous Users
+
+Anonymous users have limited access to the API.
+It is allowed to create a short url per day and it is not possible to consult any related statistics
+
+## Authenticated Users
+
+Authenticated users have greater access to the API, they can create up to 10 short_urls per minute and consult any statistics without exceeding a maximum of 100 requests per minute.
+
+Additionally, the use of the API for developers is allowed, in which case they can create up to 100 shor_urls per minute
+

--- a/YAUS/settings.py
+++ b/YAUS/settings.py
@@ -53,18 +53,24 @@ REST_FRAMEWORK = {
         'knox.auth.TokenAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES':(
-        'rest_framework.permissions.AllowAny',
+        'rest_framework.permissions.IsAuthenticated',
     ),
 
     #Rate Limiting
     'DEFAULT_THROTTLE_CLASSES': [
         'rest_framework.throttling.AnonRateThrottle',
-        'rest_framework.throttling.UserRateThrottle'
-    ],
+        'rest_framework.throttling.UserRateThrottle',
+        ],
     'DEFAULT_THROTTLE_RATES': {
-        'anon': '100/day',
-        'user': '1000/day'
+        'anon': '100/minute',
+        'anon_register_url': '1/day',
+        'anon_login': '100/minute',
+
+        'user': '100/minute',
+        'developer_register_url': '100/minute',
+        'common_register_url':'10/minute',
     },
+    
     #Pagiination 
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 10,
@@ -73,9 +79,9 @@ REST_FRAMEWORK = {
 REST_KNOX = {
     'SECURE_HASH_ALGORITHM': 'cryptography.hazmat.primitives.hashes.SHA512',
     'AUTH_TOKEN_CHARACTER_LENGTH': 64,
-    'TOKEN_TTL': timedelta(hours=10),
+    'TOKEN_TTL': timedelta(hours=1),
     'USER_SERIALIZER': 'knox.serializers.UserSerializer',
-    'TOKEN_LIMIT_PER_USER': 10,
+    'TOKEN_LIMIT_PER_USER': 100,
     'AUTO_REFRESH': True
 }
 
@@ -95,24 +101,13 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+#Cors configuration
 CORS_ALLOW_ALL_ORIGINS = True
-
-# CSRF_TRUSTED_ORIGINS = [
-#     'yaus-334b4.web.app',
-# ]
-# CSRF_COOKIE_DOMAIN = [
-#     'yaus-334b4.web.app'
-# ]
-
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOW_HEADERS  = [
     'X-CSRFTOKEN'
 ]
-
-
-
 CSRF_COOKIE_NAME = 'X-CSRFTOKEN'
-
 
 
 ROOT_URLCONF = 'YAUS.urls'

--- a/api/models.py
+++ b/api/models.py
@@ -44,7 +44,7 @@ class SetUrl(models.Model):
 
     def __str__(self):
         """return long url"""
-        return f'User: {self.user_id} | Short url: {self.short_url}'
+        return f'Long_url: {self.long_url} ; Short url: {self.short_url}'
 
 class Hit(models.Model):
     """model for hits of a set Url"""

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -34,22 +34,23 @@ class UserSerializer(serializers.ModelSerializer):
         return user
 
 
-class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
+class UserProfileSerializer(serializers.ModelSerializer):
     """Serializer for the model UserProfile"""
     class Meta:
         model = UserProfile
         fields = [
             'phone_number',
+            'Is_developer',
         ]
 
 
 class SetUrlSerializer(serializers.HyperlinkedModelSerializer):
     """Serializer for the model SetUrl"""
-    # hits = serializers.HyperlinkedRelatedField(
-    #                                             many=True,
-    #                                             read_only=True,
-    #                                             view_name='hits-detail'
-    #                                         )
+    hits = serializers.HyperlinkedRelatedField(
+                                                many=True,
+                                                read_only=True,
+                                                view_name='hits-detail'
+                                            )
     
     total_hits = serializers.SerializerMethodField()
 
@@ -62,7 +63,7 @@ class SetUrlSerializer(serializers.HyperlinkedModelSerializer):
             'short_url',
             'created',
             'total_hits',
-            # 'hits',
+            'hits',
             ]
     
     def get_total_hits(self,obj):

--- a/api/throttles.py
+++ b/api/throttles.py
@@ -1,0 +1,54 @@
+"""throttling custom model"""
+
+#rest frameword utilities
+from rest_framework import  throttling
+from django.core.exceptions import ImproperlyConfigured
+
+#model for queryset
+from api.models import UserProfile
+
+#serializer
+from api.serializers import UserProfileSerializer
+
+class AnonLoginUrlThrottle(throttling.AnonRateThrottle):
+    scope = 'anon_login'
+
+
+class AnonRegisterUrlThrottle(throttling.AnonRateThrottle):
+    scope = 'anon_register_url'
+
+class UserRegisterUrlThrottle(throttling.UserRateThrottle):
+    scope = 'user'
+
+    def resolve_scope(self,request):
+        
+        if request.user.is_anonymous:
+            return 'user'
+
+                
+        queryset = UserProfile.objects.filter(user=request.user,Is_developer=True)
+        serializer_class = UserProfileSerializer(data=queryset,many=True)
+        serializer_class.is_valid()
+        
+        if serializer_class.data:
+            scope = 'developer_register_url'
+        else: 
+            scope = 'common_register_url'
+
+        return scope
+
+    def allow_request(self, request, view):
+        # We can only determine the scope once we're called by the view.
+        self.scope = self.resolve_scope(request)
+        
+        # If a view does not have a `throttle_scope` always allow the request
+        if not self.scope:
+            return True
+
+        # Determine the allowed request rate as we normally would during
+        # the `__init__` call.
+        self.rate = self.get_rate()
+        self.num_requests, self.duration = self.parse_rate(self.rate)
+
+        # We can now proceed as normal.
+        return super().allow_request(request, view)

--- a/api/views.py
+++ b/api/views.py
@@ -34,6 +34,8 @@ from django.db.migrations import serializer
 #python utilities
 from secrets import token_urlsafe
 
+#throttle
+from api.throttles import AnonRegisterUrlThrottle, UserRegisterUrlThrottle
 
 class RegisterUserView(generics.CreateAPIView):
     """ Register a new user"""
@@ -49,7 +51,7 @@ class RegisterUserView(generics.CreateAPIView):
             user = serializer.save(validated_data=serializer.validated_data)
             
             #save profile
-            profile = UserProfile(user=user)
+            profile = UserProfile(user=user,Is_developer=False)
             profile.save()
             #making response
             data['Response'] = 'User created succesfully'
@@ -67,7 +69,8 @@ class RegisterNewUrlView(generics.CreateAPIView):
     """Register a new shor url"""
     permission_classes = [AllowAny]
     serializer_class = SetUrlSerializer
-
+    throttle_classes = [AnonRegisterUrlThrottle,UserRegisterUrlThrottle]
+    
     def create(self, request, *args, **kwargs):
         #register a new set of urls
 
@@ -94,7 +97,7 @@ class RegisterNewUrlView(generics.CreateAPIView):
                     
                     if 'short_url_custom' in request.data:
 
-                        if re.search(r'^/^/[a-z0-9-]+$/i',request.data['short_url_custom']) == None: #check if has the characters allowed
+                        if re.search(r'^[a-z0-9-]+$',request.data['short_url_custom']) == None: #check if has the characters allowed
                             data['Response'] = 'short_url_custom invalid. Only accept letters, numbers or guion'
                             return Response(data=data,status=status.HTTP_400_BAD_REQUEST) 
 
@@ -206,7 +209,7 @@ class HitViewset(viewsets.ModelViewSet):
     """ Api Endpoint for hits of users"""
     # queryset = Hit.objects.all()
     serializer_class = HitSerializer
-    
+
     def get_queryset(self):
         return Hit.objects.filter(set_url_id__user_id__username=self.request.user.username)
         

--- a/authKnox/views.py
+++ b/authKnox/views.py
@@ -34,6 +34,11 @@ from authKnox.serializers import ListTokenSerializer, TokenProfile
 #model
 from knox.models import AuthToken
 from authKnox.models import TokenProfile
+
+#throttle
+from api.throttles import AnonLoginUrlThrottle
+
+
 class ListTokenProfileView(APIView):
     """ List all token for the authenticated user"""
 
@@ -58,7 +63,7 @@ class ListTokenProfileView(APIView):
 class LoginView(LoginView):
     """Login View"""
     permission_classes = [AllowAny]
-
+    throttle_classes  = [AnonLoginUrlThrottle]
     # @ensure_csrf_cookie
     # @csrf_exempt
     def post(self, request, format=None):


### PR DESCRIPTION
- Anonymous users have limited access to the API. It is allowed to create a short url per day and it is not possible to consult any related statistics
- Authenticated users have greater access to the API, they can create up to 10 short_urls per minute and consult any statistic without exceeding a maximum of 100 requests per minute.

- Additionally, the use of the API for developers is allowed, in which case they can create up to 100 shor_urls per minute

